### PR TITLE
[IMPROVED] Differences between GitHub and GitLab are handled more efficiently

### DIFF
--- a/gitfocus-titler.pl
+++ b/gitfocus-titler.pl
@@ -1,42 +1,49 @@
 #!/usr/bin/env perl
 
-# GitFocus Helper Script
+# GitFocus Helper Script, Revision 2
 # gitfocus-titler.pl
-# 
+#
 # By Ryan Dotson
-# 18 December 2019
+# 12 January 2020
 #
 # This script is called by the GitFocus AppleScript
 # and is responsible for returning the action title based on
 # the GitLab/GitHub page title.
 #
-# You can customise the title by editing line 30 below, which
+# You can customise the title by editing line 43 below, which
 # is, by default:
 #
-#     print "resolve ❮$2❯ – ‘$1’";
+#     print "resolve ❮$issue_number❯ – ‘$issue_title’";
 #
-# Where, as explained below, $2 is the ticket number and
-# $1 is the ticket title.
 
-my $page_title = shift;
+use strict;
 
-# Match the page title against this regular expression
-# which has groups for two items:
-$page_title =~ /
-                (.+?)\s       # title ($1)
-                              # and
-                \(?
-                (\W\d+)       # ticket number ($2)
-                \)?           # parentheses are optional: GitHub
-                /igx;
+my ($page_title, $flavour) = @ARGV;
+my ($issue_title, $issue_number);
+
+
+# GitLab and GitHub have different page titles, so we need to
+# determine the issue or MR number and title using different methods.
+#
+# Here, too, we will assume that the page comes from GitLab if it's
+# not GitHub. We're also passed 'unknown' from the AppleScript in case
+# we want to check explicitly in later versions.
+
+if ($flavour eq "github") {
+    ($issue_title, $issue_number) = $page_title =~ /(.+?) · (?:Issue|Merge Request) (\W\d+)/ig;
+}
+else {
+    ($issue_title, $issue_number) = $page_title =~ /(.+?) \((\W\d+)\)/ig;
+}
 
 
 # If both title and ticket number are matched, output the title.
-if ($1 and $2) {
-    print "resolve ❮$2❯ – ‘$1’";
-}
+# Otherwise, print a string the AppleScript expects to tell it the
+# script has failed to find the information.
 
-# Otherwise output the string that the AppleScript expects.
+if ($issue_title and $issue_number) {
+    print "resolve ❮$issue_number❯ – ‘$issue_title’";
+}
 else {
     print "**NOT MATCHED**";
 }


### PR DESCRIPTION
To that end, this commit:
- Improves GitHub titling (resolves #2)
- Presumes pages are GitLab rather than GitHub (resolves #5)

Additionally:
- Stripped off trailing newlines on issue content (resolves #3)
- Made action note handling more robust; we now try to give as much about the issue as possible, rather than failing completely when anything goes wrong (resolves #4)
- Bumped version to 1.1